### PR TITLE
Phase 6: Multi-Connector Resolution

### DIFF
--- a/src/connectors/resolver.ts
+++ b/src/connectors/resolver.ts
@@ -57,6 +57,8 @@ export async function resolveAll(url: string): Promise<ResolutionResult | null> 
   }
 
   // Multiple connectors — resolve with all and merge results
+  // Note: Promise.all runs all connectors simultaneously for parallelism.
+  // For URLs matching many connectors, this could be expensive.
   const results = await Promise.all(
     connectors.map(connector => connector.resolve(url).catch(err => {
       console.warn(`Connector "${connector.id}" failed:`, err)
@@ -67,6 +69,7 @@ export async function resolveAll(url: string): Promise<ResolutionResult | null> 
   // Filter out failed resolutions
   const validResults = results.filter(Boolean) as ResolutionResult[]
 
+  // Guard against empty results array - all connectors failed
   if (validResults.length === 0) {
     return createFallbackResult(url)
   }
@@ -111,12 +114,14 @@ function mergeResults(results: ResolutionResult[], sourceUrl: string): Resolutio
     }
   }
 
-  // Merge annotations (deduplicate by @id)
+  // Merge annotations (deduplicate by @id, with generated fallback)
+  // Note: oa:hasTarget is not unique - two annotations can target the same resource.
+  // We use @id only, with a generated fallback to avoid false deduplication.
   const seenAnnotationIds = new Set<string>()
   const mergedAnnotations: ResolutionResult["annotations"] = []
   for (const result of sorted) {
     for (const ann of result.annotations || []) {
-      const annId = ann["@id"] || ann["oa:hasTarget"]
+      const annId = ann["@id"] || `ann-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
       if (!seenAnnotationIds.has(annId)) {
         seenAnnotationIds.add(annId)
         mergedAnnotations.push(ann)
@@ -134,8 +139,10 @@ function mergeResults(results: ResolutionResult[], sourceUrl: string): Resolutio
     sorted.flatMap(r => r.suggestedActions || [])
   ))
 
-  // Merge warnings (all warnings from all connectors)
-  const mergedWarnings = sorted.flatMap(r => r.warnings || [])
+  // Merge warnings (deduplicated - same warning from multiple connectors appears once)
+  const mergedWarnings = Array.from(new Set(
+    sorted.flatMap(r => r.warnings || [])
+  ))
 
   // Connector attribution
   const connectorIds = sorted.map(r => r.connector).filter(Boolean)

--- a/src/connectors/resolver.ts
+++ b/src/connectors/resolver.ts
@@ -38,6 +38,127 @@ export async function resolveUrl(url: string): Promise<ResolutionResult | null> 
 }
 
 /**
+ * Resolve a URL using all matching connectors and merge results.
+ *
+ * Returns a merged result with contributions from all connectors that can handle the URL.
+ * Results are merged with priority: higher quality results take precedence for core fields.
+ */
+export async function resolveAll(url: string): Promise<ResolutionResult | null> {
+  const connectors = registry.findAllForUrl(url)
+
+  if (connectors.length === 0) {
+    // No connectors found — return a minimal fallback
+    return createFallbackResult(url)
+  }
+
+  if (connectors.length === 1) {
+    // Single connector — use it directly
+    return connectors[0]!.resolve(url)
+  }
+
+  // Multiple connectors — resolve with all and merge results
+  const results = await Promise.all(
+    connectors.map(connector => connector.resolve(url).catch(err => {
+      console.warn(`Connector "${connector.id}" failed:`, err)
+      return null
+    }))
+  )
+
+  // Filter out failed resolutions
+  const validResults = results.filter(Boolean) as ResolutionResult[]
+
+  if (validResults.length === 0) {
+    return createFallbackResult(url)
+  }
+
+  return mergeResults(validResults, url)
+}
+
+/**
+ * Merge multiple resolution results into a single result.
+ *
+ * Priority system:
+ * - Quality: highest quality result's core fields take precedence
+ * - Representations: all unique representations are included
+ * - Annotations: all unique annotations are included
+ * - SuggestedTools: union of all tools, deduplicated
+ * - SuggestedActions: union of all actions, deduplicated
+ * - Warnings: all warnings are included
+ * - Source: attributed to all contributing connectors
+ */
+function mergeResults(results: ResolutionResult[], sourceUrl: string): ResolutionResult {
+  // Sort by quality: high > medium > low
+  const qualityOrder = { high: 3, medium: 2, low: 1 }
+  const sorted = [...results].sort((a, b) => {
+    const aQuality = qualityOrder[a.quality || "low"] || 0
+    const bQuality = qualityOrder[b.quality || "low"] || 0
+    return bQuality - aQuality
+  })
+
+  // Primary result (highest quality) provides core fields
+  const primary = sorted[0]!
+
+  // Merge representations (deduplicate by @id)
+  const seenIds = new Set<string>()
+  const mergedRepresentations: ResolutionResult["representations"] = []
+  for (const result of sorted) {
+    for (const rep of result.representations || []) {
+      const repId = rep["@id"] || rep["@type"]
+      if (!seenIds.has(repId)) {
+        seenIds.add(repId)
+        mergedRepresentations.push(rep)
+      }
+    }
+  }
+
+  // Merge annotations (deduplicate by @id)
+  const seenAnnotationIds = new Set<string>()
+  const mergedAnnotations: ResolutionResult["annotations"] = []
+  for (const result of sorted) {
+    for (const ann of result.annotations || []) {
+      const annId = ann["@id"] || ann["oa:hasTarget"]
+      if (!seenAnnotationIds.has(annId)) {
+        seenAnnotationIds.add(annId)
+        mergedAnnotations.push(ann)
+      }
+    }
+  }
+
+  // Merge suggested tools (union, preserve order)
+  const mergedTools = Array.from(new Set(
+    sorted.flatMap(r => r.suggestedTools || [])
+  ))
+
+  // Merge suggested actions (union, preserve order)
+  const mergedActions = Array.from(new Set(
+    sorted.flatMap(r => r.suggestedActions || [])
+  ))
+
+  // Merge warnings (all warnings from all connectors)
+  const mergedWarnings = sorted.flatMap(r => r.warnings || [])
+
+  // Connector attribution
+  const connectorIds = sorted.map(r => r.connector).filter(Boolean)
+  const connector = connectorIds.length > 1
+    ? `merged(${Array.from(new Set(connectorIds)).join(",")})`
+    : connectorIds[0] || "unknown"
+
+  return {
+    sourceUrl,
+    suggestedThingId: primary.suggestedThingId,
+    suggestedLabel: primary.suggestedLabel,
+    suggestedType: primary.suggestedType,
+    representations: mergedRepresentations,
+    annotations: mergedAnnotations,
+    suggestedTools: mergedTools,
+    suggestedActions: mergedActions,
+    warnings: mergedWarnings,
+    connector,
+    quality: primary.quality,
+  }
+}
+
+/**
  * Resolve a URL using a specific connector by ID.
  */
 export async function resolveWith(url: string, connectorId: string): Promise<ResolutionResult | null> {


### PR DESCRIPTION
## Phase 6: Multi-Connector Resolution (#9)

This PR adds support for resolving URLs with multiple connectors and merging their results.

### What's New

#### `resolveAll()` Function
- Resolves a URL using ALL matching connectors (not just the first)
- Returns a merged `ResolutionResult` with contributions from all connectors
- Falls back to single connector if only one matches
- Falls back to minimal result if all connectors fail

#### `mergeResults()` Function
- Merges multiple `ResolutionResult` objects into one
- **Priority system**: highest quality result provides core fields
  - `suggestedThingId`, `suggestedLabel`, `suggestedType` from highest quality
- **Union strategy** for collections:
  - All unique representations (deduplicated by `@id`)
  - All unique annotations (deduplicated by `@id` or `oa:hasTarget`)
  - All suggested tools (deduplicated)
  - All suggested actions (deduplicated)
  - All warnings from all connectors
- **Attribution**: `connector` field shows `merged(connector1,connector2,...)`

### Example

```ts
// URL matches both IIIF and JSON-LD connectors
const result = await resolveAll("https://iiif.io/api/presentation/3.0/example/manifest.json");

// Result includes:
// - Core fields from highest quality connector
// - All representations from both connectors
// - All annotations from both connectors
// - Tools: ["iiif-viewer", "jsonld-viewer"]
// - Actions: ["view-iiif", "view-jsonld"]
// - Connector: "merged(iiif,jsonld)"
```

### Benefits

1. **Richer results**: Multiple connectors can contribute different perspectives
2. **Better suggestions**: More tools and actions available to user
3. **Graceful degradation**: If one connector fails, others still contribute
4. **Transparency**: User sees which connectors contributed

### Testing

1. Test with URL matching multiple connectors:
   ```ts
   const result = await resolveAll("https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json");
   // Should merge IIIF + JSON-LD results
   ```

2. Test with URL matching single connector:
   ```ts
   const result = await resolveAll("https://example.com/image.jpg");
   // Should return ImageConnector result directly
   ```

3. Test with URL matching no connectors:
   ```ts
   const result = await resolveAll("https://example.com/unknown.xyz");
   // Should return fallback result
   ```

### Related Issues

- Closes #9
- Follows #10 (Phase 1), #13 (Phase 2), #12 (Phases 3+4+5)

### Next Steps

- All 6 phases of connector layer implementation are complete
- Ready for review and merge